### PR TITLE
fix: don't ignore changes from other loaders

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -19,6 +19,11 @@ export async function aotLoader(source: string, map: string) {
   let sourceFile: SourceFile;
   if (aotPlugin.sourceFileCache.has(this.resourcePath)) {
     sourceFile = aotPlugin.sourceFileCache.get(this.resourcePath);
+
+    // If a previous loader has changed this file, we can't use the cached sourceFile.
+    if (sourceFile.getFullText(sourceFile) !== source) {
+      sourceFile = null;
+    }
   }
 
   const isGenerated = /\.(ngfactory|ngstyle)(\.|$)/.test(this.resourcePath);


### PR DESCRIPTION
The aot plugin eagerly creates source files meaning
when using these cached versions, changes from other
loaders are ignored. This change checks if the source
from other loaders is different to the existing source
file, and if so then does not use the cached file.

In short, this allows you to apply other webpack loaders before this one.

(It seems feature/i18n is our base branch atm)